### PR TITLE
Fix old-style hash in application.html.erb

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
 						<ul class="nav navbar-nav navbar-right">
 							<li><%= link_to 'Submit link', new_link_path %></li>
 							<li><%= link_to 'Account', edit_user_registration_path %></li>
-							<li><%= link_to 'Sign out', destroy_user_session_path, :method => :delete %></li>
+							<li><%= link_to 'Sign out', destroy_user_session_path, method: delete %></li>
 						</ul>
 					<% else -%>
 						<ul class="nav navbar-nav pull-right">


### PR DESCRIPTION
`:method => delete` is Ruby 1.8 style hash and not recommended today, the new style is like `method: delete`
